### PR TITLE
Add CPU Read Interval

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -52,6 +52,7 @@ The following environment variables can be used to tune or change program`s beha
 
  * FLAMECHARTS_FOLDER: Folder where flamecharts json files will be created;
  * CPU_THRESHOLD: By Default, all processes that have more than 90 percent usage of a processor are profilled;
+ * CPU_READ_INTERVAL: By Default, pyflame will read sequentially 5 seconds of cpu use for each subprocess/worker for gunicorn. If you change this interval, be sure to check if the need time to do all reads (subprocess * CPU_READ_INTERVAL is lesser than `SCAN_INTERVAL`);
  * SCAN_INTERVAL: By Default, the scan for threads will occur every 60 seconds;
  * GUNICORN_PARENT_PID:  By Default, the cpu_monitor will try to use the first pid that is a child from pid `1`. This is a behaviour when you are using an supervisor or an minimal init system to initialize your gunicorn instance.
 

--- a/gunicorn_cpu_monitor.py
+++ b/gunicorn_cpu_monitor.py
@@ -14,6 +14,7 @@ flamechartjson = plumbum.local["flame-chart-json"]
 
 FLAMECHARTS_FOLDER = os.getenv('FLAMECHARTS_FOLDER')
 CPU_THRESHOLD = int(os.getenv('CPU_THRESHOLD', 90))
+CPU_READ_INTERVAL= int(os.getenv('CPU_READ_INTERVAL', 5)
 SCAN_INTERVAL = int(os.getenv('SCAN_INTERVAL', 60))
 GUNICORN_PARENT_PID = int(os.getenv('GUNICORN_PARENT_PID', 1))
 
@@ -29,7 +30,7 @@ def setup_logging():
 def get_gunicorn_high_cpu_children_processes(gunicorn_master_pid, threshold=CPU_THRESHOLD):
     gunicorn_subprocesses = psutil.Process(gunicorn_master_pid).children(recursive=True)
 
-    return [children for children in gunicorn_subprocesses if children.cpu_percent() > threshold]
+    return [children for children in gunicorn_subprocesses if children.cpu_percent(interval=CPU_READ_INTERVAL) > threshold]
 
 
 def generate_flamechart_files_for_processes(processes):


### PR DESCRIPTION
## Bug

Withtout an interval, the cpu_monitor will return 0.0 as cpu_percent read per children proccesses most of the time.

## Fixes 

- [x] Add an `CPU_READ_INTERVAL` environment var, with the default value of 5, which is the time in seconds that pyflame will watch the process cpu use before returning avg values.
- [x] Update `README.MD` with the `CPU_READ_INTERVAL` info.